### PR TITLE
fix: add w to alphabet enums

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -77,15 +77,6 @@ describe('parse', () => {
         expect(!!out.flags.myflag).to.equal(true)
         expect(!!out.flags.force).to.equal(true)
       })
-
-      it('knows "w" is a character', () => {
-        const out = parse(['-w'], {
-          flags: {
-            wobble: flags.boolean({char: 'w'}),
-          }
-        })
-        expect(!!out.flags.wobble).to.equal(true)
-      })
     })
     it('parses flag value with "=" to separate', () => {
       const out = parse(['--myflag=foo'], {


### PR DESCRIPTION
i tried to use `w` as the shorter version for a command flag. typescript said it wasn't assignable.